### PR TITLE
Use lodash.includes instead of lodash.contains

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "interface-connection": "0.3.0",
     "ip-address": "^5.8.0",
-    "lodash.contains": "^2.4.3",
+    "lodash.includes": "^4.3.0",
     "mafmt": "^2.1.2",
     "multiaddr": "^2.1.1",
     "stream-to-pull-stream": "^1.7.0"

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 const net = require('net')
 const toPull = require('stream-to-pull-stream')
 const mafmt = require('mafmt')
-const contains = require('lodash.contains')
+const includes = require('lodash.includes')
 const isFunction = require('lodash.isfunction')
 const Connection = require('interface-connection').Connection
 const debug = require('debug')
@@ -59,7 +59,7 @@ module.exports = class TCP {
       multiaddrs = [multiaddrs]
     }
     return multiaddrs.filter((ma) => {
-      if (contains(ma.protoNames(), 'ipfs')) {
+      if (includes(ma.protoNames(), 'ipfs')) {
         ma = ma.decapsulate('ipfs')
       }
       return mafmt.TCP.matches(ma)

--- a/src/listener.js
+++ b/src/listener.js
@@ -3,7 +3,7 @@
 const multiaddr = require('multiaddr')
 const Connection = require('interface-connection').Connection
 const os = require('os')
-const contains = require('lodash.contains')
+const includes = require('lodash.includes')
 const net = require('net')
 const toPull = require('stream-to-pull-stream')
 const EventEmitter = require('events').EventEmitter
@@ -78,7 +78,7 @@ module.exports = (handler) => {
 
   listener.listen = (ma, cb) => {
     listeningAddr = ma
-    if (contains(ma.protoNames(), 'ipfs')) {
+    if (includes(ma.protoNames(), 'ipfs')) {
       ipfsId = getIpfsId(ma)
       listeningAddr = ma.decapsulate('ipfs')
     }


### PR DESCRIPTION
To silence this warning:  
```
npm WARN deprecated lodash.contains@2.4.3: This package is discontinued. Use lodash.includes@^4.0.0.
```