### PR TITLE
feat: skip p2p-circuit addresses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,9 @@ class TCP {
       multiaddrs = [multiaddrs]
     }
     return multiaddrs.filter((ma) => {
-      if (includes(ma.protoNames(), 'ipfs')) {
+      if (includes(ma.protoNames(), 'p2p-circuit')) {
+        return false
+      } else if (includes(ma.protoNames(), 'ipfs')) {
         ma = ma.decapsulate('ipfs')
       }
       return mafmt.TCP.matches(ma)


### PR DESCRIPTION
Ignore `/p2p-circuit` addresses