### PR TITLE
Fixing the broken example in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ docs
 test/repo-tests*
 **/bundle.js
 
+# yarn
+yarn.lock
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ const listener = tcp.createListener((socket) => {
   )
 })
 
-listener.listen(mh1, () => {
+listener.listen(mh, () => {
   console.log('listening')
 
   pull(
-    tcp.dial(mh1),
+    tcp.dial(mh),
     pull.collect((err, values) => {
       if (!err) {
         console.log(`Value: ${values.toString()}`)

--- a/README.md
+++ b/README.md
@@ -39,12 +39,11 @@ const TCP = require('libp2p-tcp')
 const multiaddr = require('multiaddr')
 const pull = require('pull-stream')
 
-const mh1 = multiaddr('/ip4/127.0.0.1/tcp/9090')
-const mh2 = multiaddr('/ip6/::/tcp/9092')
+const mh = multiaddr('/ip4/127.0.0.1/tcp/9090')
 
 const tcp = new TCP()
 
-const listener = tcp.createListener(mh1, (socket) => {
+const listener = tcp.createListener((socket) => {
   console.log('new connection opened')
   pull(
     pull.values(['hello']),
@@ -52,15 +51,21 @@ const listener = tcp.createListener(mh1, (socket) => {
   )
 })
 
-listener.listen(() => {
+listener.listen(mh1, () => {
   console.log('listening')
 
   pull(
     tcp.dial(mh1),
-    pull.log,
-    pull.onEnd(() => {
-      tcp.close()
-    })
+    pull.collect((err, values) => {
+      if (!err) {
+        console.log(`Value: ${values.toString()}`)
+      } else {
+        console.log(`Error: ${err}`)
+      }
+
+      // Close connection after reading
+      listener.close()
+    }),
   )
 })
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Outputs:
 ```sh
 listening
 new connection opened
-hello
+Value: hello
 ```
 
 ## API


### PR DESCRIPTION
Added a working example that listens at a given tcp address, dials the address, and prints the response before closing the listener.

Issue: https://github.com/libp2p/js-libp2p-tcp/issues/89