### PR TITLE
fix: "invalid ip address" "daemon can be crashed by remote user"

### DIFF
--- a/src/get-multiaddr.js
+++ b/src/get-multiaddr.js
@@ -2,27 +2,32 @@
 
 const multiaddr = require('multiaddr')
 const Address6 = require('ip-address').Address6
+const debug = require('debug')
+const log = debug('libp2p:tcp:get-multiaddr')
 
 module.exports = (socket) => {
   let ma
 
-  if (socket.remoteFamily === 'IPv6') {
-    const addr = new Address6(socket.remoteAddress)
+  try {
+    if (socket.remoteFamily === 'IPv6') {
+      const addr = new Address6(socket.remoteAddress)
 
-    if (addr.v4) {
-      const ip4 = addr.to4().correctForm()
-      ma = multiaddr('/ip4/' + ip4 +
-        '/tcp/' + socket.remotePort
-      )
+      if (addr.v4) {
+        const ip4 = addr.to4().correctForm()
+        ma = multiaddr('/ip4/' + ip4 +
+          '/tcp/' + socket.remotePort
+        )
+      } else {
+        ma = multiaddr('/ip6/' + socket.remoteAddress +
+          '/tcp/' + socket.remotePort
+        )
+      }
     } else {
-      ma = multiaddr('/ip6/' + socket.remoteAddress +
-        '/tcp/' + socket.remotePort
-      )
+      ma = multiaddr('/ip4/' + socket.remoteAddress +
+        '/tcp/' + socket.remotePort)
     }
-  } else {
-    ma = multiaddr('/ip4/' + socket.remoteAddress +
-      '/tcp/' + socket.remotePort)
+  } catch (err) {
+    log(err)
   }
-
   return ma
 }

--- a/src/listener.js
+++ b/src/listener.js
@@ -25,6 +25,15 @@ module.exports = (handler) => {
     socket.on('error', noop)
 
     const addr = getMultiaddr(socket)
+    if (!addr) {
+      if (socket.remoteAddress === undefined) {
+        log('connection closed before p2p connection made')
+      } else {
+        log('error interpreting incoming p2p connection')
+      }
+      return
+    }
+
     log('new connection', addr.toString())
 
     const s = toPull.duplex(socket)

--- a/test/get-multiaddr.spec.js
+++ b/test/get-multiaddr.spec.js
@@ -1,0 +1,54 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const getMultiaddr = require('../src/get-multiaddr')
+
+const goodSocket4 = {
+  remoteAddress: '127.0.0.1',
+  remotePort: '9090',
+  remoteFamily: 'IPv4'
+}
+
+const goodSocket6 = {
+  remoteAddress: '::1',
+  remotePort: '9090',
+  remoteFamily: 'IPv6'
+}
+
+const badSocket = {}
+
+const badSocketData = {
+  remoteAddress: 'aewmrn4awoew',
+  remotePort: '234',
+  remoteFamily: 'Hufflepuff'
+}
+
+describe('getMultiaddr multiaddr creation', () => {
+  it('creates multiaddr from valid socket data', (done) => {
+    expect(getMultiaddr(goodSocket4))
+      .to.exist()
+    done()
+  })
+
+  it('creates multiaddr from valid IPv6 socket data', (done) => {
+    expect(getMultiaddr(goodSocket6))
+      .to.exist()
+    done()
+  })
+
+  it('returns undefined multiaddr from missing socket data', (done) => {
+    expect(getMultiaddr(badSocket))
+      .to.equal(undefined)
+    done()
+  })
+
+  it('returns undefined multiaddr from unparseable socket data', (done) => {
+    expect(getMultiaddr(badSocketData))
+      .to.equal(undefined)
+    done()
+  })
+})


### PR DESCRIPTION
Hello maintainers! I saw the remote vulnerability from js-ipfs #1447
and hunted it down. Are there any problems with or possible 
improvements to this proposed solution? I believe it will also resolve
js-libp2p-tcp issue #93 

Cheers,

Tom

--


Per the nodeJS documentation, a Net socket.remoteAddress value may
be undefined if the socket is destroyed, as by a client disconnect.
A multiaddr cannot be created for an invalid IP address (such as
the undefined remote address of a destroyed socket). Currently
the attempt results in a crash that can be triggered remotely. This
commit terminates processing of a destroyed socket before multiaddr
causes the crash.

fixes: https://github.com/libp2p/js-libp2p-tcp/issues/93
fixes: https://github.com/ipfs/js-ipfs/issues/1447