### PR TITLE
feat: add support for dialing over dns

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dirty-chai": "^2.0.1",
     "interface-transport": "~0.3.6",
     "lodash.isfunction": "^3.0.9",
-    "pull-stream": "^3.6.7"
+    "pull-stream": "^3.6.9"
   },
   "dependencies": {
     "class-is": "^1.1.0",
@@ -48,8 +48,8 @@
     "ip-address": "^5.8.9",
     "lodash.includes": "^4.3.0",
     "lodash.isfunction": "^3.0.9",
-    "mafmt": "^6.0.0",
-    "multiaddr": "^4.0.0",
+    "mafmt": "^6.0.2",
+    "multiaddr": "^5.0.0",
     "once": "^1.4.0",
     "stream-to-pull-stream": "^1.7.2"
   },

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -12,7 +12,8 @@ describe('interface-transport compliance', () => {
       const addrs = [
         multiaddr('/ip4/127.0.0.1/tcp/9091'),
         multiaddr('/ip4/127.0.0.1/tcp/9092'),
-        multiaddr('/ip4/127.0.0.1/tcp/9093')
+        multiaddr('/ip4/127.0.0.1/tcp/9093'),
+        multiaddr('/dns4/ipfs.io')
       ]
       cb(null, tcp, addrs)
     },

--- a/test/filter.spec.js
+++ b/test/filter.spec.js
@@ -25,9 +25,11 @@ describe('filter addrs', () => {
     const ma4 = multiaddr(base + '/tcp/9090/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
     const ma5 = multiaddr(base + '/tcp/9090/http' + ipfs)
     const ma6 = multiaddr('/ip4/127.0.0.1/tcp/9090/p2p-circuit' + ipfs)
+    const ma7 = multiaddr('/dns4/libp2p.io/tcp/9090')
+    const ma8 = multiaddr('/dnsaddr/libp2p.io/tcp/9090')
 
-    const valid = tcp.filter([ma1, ma2, ma3, ma4, ma5, ma6])
-    expect(valid.length).to.equal(2)
+    const valid = tcp.filter([ma1, ma2, ma3, ma4, ma5, ma6, ma7, ma8])
+    expect(valid.length).to.equal(4)
     expect(valid[0]).to.deep.equal(ma1)
     expect(valid[1]).to.deep.equal(ma4)
   })


### PR DESCRIPTION
Adds support for dialing over DNS. `mafmt` was previously limiting tcp addresses to only IP. An update was released to allow for DNS in mafmt@0.6.2. 

Resolves #95 

I used the example code mentioned in the issue, libp2p/js-libp2p-switch#277, to successfully connect to the ipfs jupiter node over dns via the following addresses:

/dns4/jupiter.i.ipfs.io/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx
/dnsaddr/jupiter.i.ipfs.io/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx

cc: @mgoelzer 