### PR TITLE
Prefer const over let

### DIFF
--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -8,7 +8,7 @@ const TCP = require('../src')
 describe('interface-transport compliance', () => {
   tests({
     setup (cb) {
-      let tcp = new TCP()
+      const tcp = new TCP()
       const addrs = [
         multiaddr('/ip4/127.0.0.1/tcp/9091'),
         multiaddr('/ip4/127.0.0.1/tcp/9092'),


### PR DESCRIPTION
In order to comply with this new standard rule ☺️ 

https://github.com/standard/eslint-config-standard/pull/133