### PR TITLE
Cancel dials with AbortController

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pull-stream": "^3.6.9"
   },
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "async-iterator-to-pull-stream": "^1.3.0",
     "class-is": "^1.1.0",
     "debug": "^3.1.0",
@@ -55,7 +56,8 @@
     "lodash.includes": "^4.3.0",
     "lodash.isfunction": "^3.0.9",
     "mafmt": "^6.0.2",
-    "multiaddr": "^5.0.0"
+    "multiaddr": "^5.0.0",
+    "sinon": "^7.3.1"
   },
   "contributors": [
     "Alan Shaw <alan@tableflip.io>",

--- a/test/dial-cancel.spec.js
+++ b/test/dial-cancel.spec.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const TCP = require('../src')
+const net = require('net')
+const AbortController = require('abort-controller')
+const multiaddr = require('multiaddr')
+const pipe = require('it-pipe')
+const sinon = require('sinon')
+
+describe('dial cancel', () => {
+  let tcp
+  let listener
+  const ma = multiaddr('/ip4/127.0.0.1/tcp/9090')
+
+  beforeEach(() => {
+    tcp = new TCP()
+    listener = tcp.createListener((conn) => pipe(conn, conn))
+    return listener.listen(ma)
+  })
+
+  afterEach(() => listener.close())
+
+  it('cancel before dialing', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const socket = tcp.dial(ma, { signal: controller.signal })
+
+    try {
+      await socket
+    } catch (err) {
+      expect(err.code).to.eql('ABORT_ERR')
+      return
+    }
+    expect.fail('Did not throw error')
+  })
+
+  it('cancel while dialing', async () => {
+    // Add a delay to net.connect() so that we can cancel while the dial is in
+    // progress
+    const netConnect = net.connect
+    sinon.replace(net, 'connect', (opts) => {
+      const socket = netConnect(opts)
+      const socketEmit = socket.emit.bind(socket)
+      sinon.replace(socket, 'emit', (...args) => {
+        const delay = args[0] === 'connect' ? 100 : 0
+        // eslint-disable-next-line max-nested-callbacks
+        setTimeout(() => socketEmit(...args), delay)
+      })
+      return socket
+    })
+
+    const controller = new AbortController()
+    const socket = tcp.dial(ma, { signal: controller.signal })
+    setTimeout(() => {
+      controller.abort()
+    }, 10)
+
+    try {
+      await socket
+    } catch (err) {
+      expect(err.code).to.eql('ABORT_ERR')
+      return
+    } finally {
+      sinon.restore()
+    }
+    expect.fail('Did not throw error')
+  })
+})


### PR DESCRIPTION
Implement dial cancelling with AbortController

Usage:
```Javascript
const controller = new AbortController()
try {
  const socket = await tcp.dial(ma, { signal: controller.signal })
  // Do stuff with socket here ...
} catch (err) {
  if(err instanceof tcp.AbortError) {
    // Dial got aborted, just bail out
    return
  }
  throw err
}

// ----
// In some other part of the code:
  controller.abort()
// ----
```

To be honest catching and then checking the error type seems a little complicated. How would people feel about `transport.dial()` returning `null` if there's an abort, eg:
```Javascript
const controller = new AbortController()
const socket = await tcp.dial(ma, { signal: controller.signal })
if (!socket) {
  // Dial got aborted, just bail out
  return
}
// Do stuff with socket here ...

// ----
// In some other part of the code:
  controller.abort()
// ----
```
