### PR TITLE
Generate Typescript Typings via JsDoc

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,0 +1,12 @@
+{
+    "recurseDepth": 10,
+    "source": {
+        "include": ["src/"],
+        "exclude": ["node_modules"]
+    },
+    "opts": {
+        "destination": "src/",
+        "template": "./node_modules/tsd-jsdoc/dist",
+        "recurse": true
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
         - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
+        - npm run generate-typings
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "release-minor": "aegir release -t node --type minor --no-build",
     "release-major": "aegir-release -t node --type major --no-build",
     "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage --provider coveralls"
+    "coverage-publish": "aegir coverage --provider coveralls",
+    "generate-typings": "./node_modules/.bin/jsdoc -c ./.jsdoc.json"
   },
   "pre-push": [
     "lint",
@@ -39,7 +40,10 @@
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "interface-transport": "~0.3.6",
-    "pull-stream": "^3.6.14"
+    "jsdoc": "^3.6.3",
+    "pull-stream": "^3.6.14",
+    "tsd-jsdoc": "^2.3.1",
+    "typescript-definition-tester": "0.0.6"
   },
   "dependencies": {
     "class-is": "^1.1.0",

--- a/src/get-multiaddr.js
+++ b/src/get-multiaddr.js
@@ -1,11 +1,18 @@
 'use strict'
-
+/**
+ * @module js-libp2p-tcp/get-multiaddr
+ */
 const multiaddr = require('multiaddr')
 const Address6 = require('ip-address').Address6
 const debug = require('debug')
 const log = debug('libp2p:tcp:get-multiaddr')
 
-module.exports = (socket) => {
+/**
+ * @type {function}
+ * @param {*} socket
+ * @returns {*}
+ */
+function getMultiAddr (socket) {
   let ma
 
   try {
@@ -31,3 +38,5 @@ module.exports = (socket) => {
   }
   return ma
 }
+
+module.exports = getMultiAddr

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 'use strict'
-
+/**
+ * @module js-libp2p-tcp
+ */
 const net = require('net')
 const toPull = require('stream-to-pull-stream')
 const mafmt = require('mafmt')
@@ -15,7 +17,17 @@ const createListener = require('./listener')
 
 function noop () {}
 
+/**
+ * @class
+ */
 class TCP {
+  /**
+   *
+   * @param {*} ma
+   * @param {object} options
+   * @param {function} callback
+   * @returns {*}
+   */
   dial (ma, options, callback) {
     if (isFunction(options)) {
       callback = options
@@ -52,6 +64,12 @@ class TCP {
     return conn
   }
 
+  /**
+   *
+   * @param {object} options
+   * @param {function} handler
+   * @returns {*}
+   */
   createListener (options, handler) {
     if (isFunction(options)) {
       handler = options
@@ -63,6 +81,11 @@ class TCP {
     return createListener(handler)
   }
 
+  /**
+   *
+   * @param {Array<*>|*} multiaddrs
+   * @returns {*}
+   */
   filter (multiaddrs) {
     if (!Array.isArray(multiaddrs)) {
       multiaddrs = [multiaddrs]

--- a/src/listener.js
+++ b/src/listener.js
@@ -1,4 +1,7 @@
 'use strict'
+/**
+ * @module js-libp2p-tcp/listener
+ */
 
 const multiaddr = require('multiaddr')
 const Connection = require('interface-connection').Connection
@@ -17,7 +20,12 @@ const CLOSE_TIMEOUT = 2000
 
 function noop () {}
 
-module.exports = (handler) => {
+/**
+ * @type {function}
+ * @param {function} handler
+ * @returns {*}
+ */
+function listener (handler) {
   const listener = new EventEmitter()
 
   const server = net.createServer((socket) => {
@@ -139,6 +147,8 @@ module.exports = (handler) => {
 
   return listener
 }
+
+module.exports = listener
 
 function getIpfsId (ma) {
   return ma.stringTuples().filter((tuple) => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,53 @@
+/**
+ * @module js-libp2p-tcp/get-multiaddr
+ */
+declare module "js-libp2p-tcp/get-multiaddr" {
+    /**
+     * @type {function}
+     * @param {*} socket
+     * @returns {*}
+     */
+    function getMultiAddr(socket: any): any;
+}
+
+/**
+ * @module js-libp2p-tcp
+ */
+declare module "js-libp2p-tcp" {
+    /**
+     * @class
+     */
+    class TCP {
+        /**
+         *
+         * @param {*} ma
+         * @param {object} options
+         * @param {function} callback
+         */
+        dial(ma: any, options: any, callback: (...params: any[]) => any): void;
+        /**
+         *
+         * @param {object} options
+         * @param {function} handler
+         */
+        createListener(options: any, handler: (...params: any[]) => any): void;
+        /**
+         *
+         * @param {Array<*>|*} multiaddrs
+         */
+        filter(multiaddrs: any[] | any): void;
+    }
+}
+
+/**
+ * @module js-libp2p-tcp/listener
+ */
+declare module "js-libp2p-tcp/listener" {
+    /**
+     * @type {function}
+     * @param {function} handler
+     * @returns {*}
+     */
+    function listener(handler: (...params: any[]) => any): any;
+}
+


### PR DESCRIPTION
Generates Typescript Typings via JsDoc

* Adds typings to thejs-libp2p-tcp module
* Add typings generation to travis.yml
* Include typings test