### PR TITLE
fix: ensure timeline.close is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 package-lock.json
 coverage
 .nyc_output
+docs

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "aegir": "^20.0.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "interface-transport": "^0.6.1",
+    "interface-transport": "^0.7.0",
     "sinon": "^7.3.1"
   },
   "dependencies": {
@@ -45,7 +45,7 @@
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
     "ip-address": "^6.1.0",
-    "mafmt": "^6.0.9",
+    "mafmt": "^7.0.0",
     "multiaddr": "^7.1.0",
     "stream-to-it": "^0.1.1"
   },

--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -79,5 +79,14 @@ module.exports = (socket, options) => {
     }
   }
 
+  socket.once('close', () => {
+    // In instances where `close` was not explicitly called,
+    // such as an iterable stream ending, ensure we have set the close
+    // timeline
+    if (!maConn.timeline.close) {
+      maConn.timeline.close = Date.now()
+    }
+  })
+
   return maConn
 }

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -14,8 +14,7 @@ describe('interface-transport compliance', () => {
       const addrs = [
         multiaddr('/ip4/127.0.0.1/tcp/9091'),
         multiaddr('/ip4/127.0.0.1/tcp/9092'),
-        multiaddr('/ip4/127.0.0.1/tcp/9093'),
-        multiaddr('/dns4/ipfs.io')
+        multiaddr('/ip4/127.0.0.1/tcp/9093')
       ]
 
       // Used by the dial tests to simulate a delayed connect


### PR DESCRIPTION
The latest `interface-transport` includes tests to ensure timeline values are set properly. This exposed a bug where we did not set `close` when the socket ended without calling `close` on the MultiaddrConnection explicitly. This fixes that by listening for the close event on the socket from the start.

I removed `multiaddr('/dns4/ipfs.io')` from the compliance list of addresses. `filter` is now tested in `interface-transport` and it shows that this is not a valid TCP address. DNS addresses should be resolved into TCP addresses before being passed to the transport.