### PR TITLE
fix: support multiaddr 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "interface-transport": "~0.3.6",
-    "pull-stream": "^3.6.14"
+    "pull-stream": "^3.6.14",
+    "multiaddr7": "npm:multiaddr@^7.0.0"
   },
   "dependencies": {
     "class-is": "^1.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,9 @@ class TCP {
         return false
       }
 
-      if (includes(ma.protoNames(), 'ipfs')) {
+      if (typeof ma.decapsulateCode === 'function') {
+        ma = ma.decapsulateCode(421) // multiaddr 7
+      } else if (includes(ma.protoNames(), 'ipfs')) {
         ma = ma.decapsulate('ipfs')
       }
 

--- a/src/listener.js
+++ b/src/listener.js
@@ -84,7 +84,10 @@ module.exports = (handler) => {
 
   listener.listen = (ma, callback) => {
     listeningAddr = ma
-    if (includes(ma.protoNames(), 'ipfs')) {
+    if (typeof ma.decapsulateCode === 'function') {
+      ipfsId = getIpfsId(ma)
+      listeningAddr = ma.decapsulateCode(IPFS_CODE)
+    } else if (includes(ma.protoNames(), 'ipfs')) {
       ipfsId = getIpfsId(ma)
       listeningAddr = ma.decapsulate('ipfs')
     }

--- a/test/filter.spec.js
+++ b/test/filter.spec.js
@@ -7,6 +7,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 const TCP = require('../src')
 const multiaddr = require('multiaddr')
+const multiaddr7 = require('multiaddr7')
 
 describe('filter addrs', () => {
   const base = '/ip4/127.0.0.1'
@@ -27,11 +28,13 @@ describe('filter addrs', () => {
     const ma6 = multiaddr('/ip4/127.0.0.1/tcp/9090/p2p-circuit' + ipfs)
     const ma7 = multiaddr('/dns4/libp2p.io/tcp/9090')
     const ma8 = multiaddr('/dnsaddr/libp2p.io/tcp/9090')
+    const ma9 = multiaddr7(base + '/tcp/9090/p2p/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
 
-    const valid = tcp.filter([ma1, ma2, ma3, ma4, ma5, ma6, ma7, ma8])
-    expect(valid.length).to.equal(4)
+    const valid = tcp.filter([ma1, ma2, ma3, ma4, ma5, ma6, ma7, ma8, ma9])
+    expect(valid.length).to.equal(5)
     expect(valid[0]).to.deep.equal(ma1)
     expect(valid[1]).to.deep.equal(ma4)
+    expect(valid[4]).to.deep.equal(ma9)
   })
 
   it('filter a single addr for this transport', () => {

--- a/test/listen-dial.spec.js
+++ b/test/listen-dial.spec.js
@@ -9,6 +9,7 @@ chai.use(dirtyChai)
 const TCP = require('../src')
 const net = require('net')
 const multiaddr = require('multiaddr')
+const multiaddr7 = require('multiaddr7')
 const isCI = process.env.CI
 
 describe('listen', () => {
@@ -244,6 +245,21 @@ describe('dial', () => {
 
   it('dial on IPv4 with IPFS Id', (done) => {
     const ma = multiaddr('/ip4/127.0.0.1/tcp/9090/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
+    const conn = tcp.dial(ma)
+
+    pull(
+      pull.values(['hey']),
+      conn,
+      pull.collect((err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.be.eql([Buffer.from('hey!')])
+        done()
+      })
+    )
+  })
+
+  it('dial on IPv4 with IPFS Id multiaddr7', (done) => {
+    const ma = multiaddr7('/ip4/127.0.0.1/tcp/9090/p2p/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
     const conn = tcp.dial(ma)
 
     pull(

--- a/test/listen-dial.spec.js
+++ b/test/listen-dial.spec.js
@@ -127,6 +127,19 @@ describe('listen', () => {
       })
     })
   })
+
+  it('getAddrs preserves IPFS Id (multiaddr 7)', (done) => {
+    const mh = multiaddr7('/ip4/127.0.0.1/tcp/9090/p2p/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
+    const listener = tcp.createListener((conn) => {})
+    listener.listen(mh, () => {
+      listener.getAddrs((err, multiaddrs) => {
+        expect(err).to.not.exist()
+        expect(multiaddrs.length).to.equal(1)
+        expect(multiaddrs[0]).to.deep.equal(mh)
+        listener.close(done)
+      })
+    })
+  })
 })
 
 describe('dial', () => {


### PR DESCRIPTION
This adds multiaddr 7 support to filtering, for the 0.13.x line. multiaddr 7 uses `p2p` instead of `ipfs`. Since we currently decapsulate with 'ipfs' this causes valid addresses to get filtered out. Filter will now check for `decapsulateCode` on the multiaddr and use that if it exists, otherwise it defaults to its previous behavior.