### PR TITLE
fix: log the bound port and host

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -59,8 +59,7 @@ module.exports = ({ handler, upgrader }, options) => {
       const { host, port } = listeningAddr.toOptions()
       server.listen(port, host, err => {
         if (err) return reject(err)
-        const { address, port } = server.address()
-        log('Listening on %s:%s', address, port)
+        log('Listening on %s', server.address())
         resolve()
       })
     })

--- a/src/listener.js
+++ b/src/listener.js
@@ -59,7 +59,8 @@ module.exports = ({ handler, upgrader }, options) => {
       const { host, port } = listeningAddr.toOptions()
       server.listen(port, host, err => {
         if (err) return reject(err)
-        log('Listening on %s %s', port, host)
+        const { address, port } = server.address()
+        log('Listening on %s:%s', address, port)
         resolve()
       })
     })


### PR DESCRIPTION
This fixes logging for ephemeral address listening. Instead of logging `0.0.0.0:0`, this will log the actual local address and port.