### PR TITLE
fix: transport should not handle connection if upgradeInbound throws

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "aegir": "^20.4.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p-interfaces": "^0.1.6",
+    "libp2p-interfaces": "^0.2.0",
     "it-pipe": "^1.1.0",
     "sinon": "^7.5.0",
     "streaming-iterables": "^4.1.1"


### PR DESCRIPTION
Fixed per discussion on [libp2p/js-libp2p#523#discussion_r359997872](https://github.com/libp2p/js-libp2p/pull/523#discussion_r359997872)