### PR TITLE
fix: remove use of assert module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ const createListener = require('./listener')
 const { multiaddrToNetConfig } = require('./utils')
 const { AbortError } = require('abortable-iterator')
 const { CODE_CIRCUIT, CODE_P2P } = require('./constants')
-const assert = require('assert')
 
 /**
  * @class TCP
@@ -22,7 +21,9 @@ class TCP {
    * @param {Upgrader} options.upgrader
    */
   constructor ({ upgrader }) {
-    assert(upgrader, 'An upgrader must be provided. See https://github.com/libp2p/interface-transport#upgrader.')
+    if (!upgrader) {
+      throw new Error('An upgrader must be provided. See https://github.com/libp2p/interface-transport#upgrader.')
+    }
     this._upgrader = upgrader
   }
 


### PR DESCRIPTION
The polyfill is big, we can simulate it by throwing an Error and it doesn't work under React Native.