### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
   },
   "devDependencies": {
     "aegir": "^25.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
     "libp2p-interfaces": "^0.3.1",
     "it-pipe": "^1.1.0",
     "sinon": "^9.0.0",
@@ -48,7 +46,7 @@
     "err-code": "^2.0.0",
     "libp2p-utils": "^0.1.2",
     "mafmt": "^7.1.0",
-    "multiaddr": "^7.5.0",
+    "multiaddr": "^8.0.0",
     "stream-to-it": "^0.2.2"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
-    "libp2p-utils": "achingbrain/js-libp2p-utils#chore/update-deps",
+    "libp2p-utils": "^0.2.0",
     "mafmt": "^7.1.0",
     "multiaddr": "^8.0.0",
     "stream-to-it": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
-    "libp2p-utils": "^0.1.2",
+    "libp2p-utils": "achingbrain/js-libp2p-utils#chore/update-deps",
     "mafmt": "^7.1.0",
     "multiaddr": "^8.0.0",
     "stream-to-it": "^0.2.2"

--- a/test/connection.spec.js
+++ b/test/connection.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const TCP = require('../src')
 const multiaddr = require('multiaddr')
 

--- a/test/filter.spec.js
+++ b/test/filter.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const TCP = require('../src')
 const multiaddr = require('multiaddr')
 

--- a/test/listen-dial.spec.js
+++ b/test/listen-dial.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const TCP = require('../src')
 const net = require('net')
 const os = require('os')


### PR DESCRIPTION
Upgrades to the latest multiaddrs with Uint8Arrays

Also removes redundant deps.

Depends on:

- [x] https://github.com/libp2p/js-libp2p-utils/pull/9

BREAKING CHANGES:

- The multiaddr dep used by this module returns Uint8Arrays and may
  not be compatible with previous versions