### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "aegir": "^25.0.0",
-    "libp2p-interfaces": "^0.3.1",
     "it-pipe": "^1.1.0",
+    "libp2p-interfaces": "^0.4.0",
     "sinon": "^9.0.0",
     "streaming-iterables": "^5.0.2"
   },


### PR DESCRIPTION
Pulls in the latest interface module that depends on modules that
use Uint8Arrays in place of node Buffers.