### PR TITLE
fix: ts declaration export

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "types": "dist/src/index.d.ts",
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "aegir": "^33.2.0",
+    "aegir": "^35.0.3",
     "it-pipe": "^1.1.0",
     "libp2p-interfaces": "^1.0.0",
     "libp2p-interfaces-compliance-tests": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -151,4 +151,6 @@ class TCP {
   }
 }
 
-module.exports = withIs(TCP, { className: 'TCP', symbolName: '@libp2p/js-libp2p-tcp/tcp' })
+const TCPWithIs = withIs(TCP, { className: 'TCP', symbolName: '@libp2p/js-libp2p-tcp/tcp' })
+
+exports = module.exports = TCPWithIs


### PR DESCRIPTION
Closes #149 

New build looks like:

```
export = TCPWithIs;
declare const TCPWithIs: any;
declare namespace TCPWithIs {
    export { Multiaddr, Connection, Upgrader, Listener, Socket };
}
type Multiaddr = import('multiaddr').Multiaddr;
type Connection = import("libp2p-interfaces/src/connection/connection");
type Upgrader = import('libp2p-interfaces/src/transport/types').Upgrader;
type Listener = import('libp2p-interfaces/src/transport/types').Listener;
type Socket = import('net').Socket;
//# sourceMappingURL=index.d.ts.map
```