### PR TITLE
fix: pass abort signal to upgrader

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   "types": "dist/src/index.d.ts",
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "aegir": "^35.0.3",
+    "aegir": "^36.1.1",
     "it-pipe": "^1.1.0",
-    "libp2p-interfaces": "^1.0.0",
-    "libp2p-interfaces-compliance-tests": "^1.0.0",
-    "sinon": "^11.1.1",
+    "libp2p-interfaces": "^2.0.3",
+    "libp2p-interfaces-compliance-tests": "^2.0.4",
+    "sinon": "^12.0.1",
     "streaming-iterables": "^6.0.0"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const { CODE_CIRCUIT, CODE_P2P } = require('./constants')
  * @typedef {import('libp2p-interfaces/src/transport/types').Upgrader} Upgrader
  * @typedef {import('libp2p-interfaces/src/transport/types').Listener} Listener
  * @typedef {import('net').Socket} Socket
+ * @typedef {import('libp2p-interfaces/src/types').AbortOptions} AbortOptions
  */
 
 class TCP {
@@ -37,8 +38,7 @@ class TCP {
   /**
    * @async
    * @param {Multiaddr} ma
-   * @param {object} options
-   * @param {AbortSignal} [options.signal] - Used to abort dial requests
+   * @param {AbortOptions} options
    * @returns {Promise<Connection>} An upgraded Connection
    */
   async dial (ma, options) {
@@ -46,7 +46,7 @@ class TCP {
     const socket = await this._connect(ma, options)
     const maConn = toConnection(socket, { remoteAddr: ma, signal: options.signal })
     log('new outbound connection %s', maConn.remoteAddr)
-    const conn = await this._upgrader.upgradeOutbound(maConn)
+    const conn = await this._upgrader.upgradeOutbound(maConn, options)
     log('outbound connection %s upgraded', maConn.remoteAddr)
     return conn
   }
@@ -54,8 +54,7 @@ class TCP {
   /**
    * @private
    * @param {Multiaddr} ma
-   * @param {object} options
-   * @param {AbortSignal} [options.signal] - Used to abort dial requests
+   * @param {AbortOptions} options
    * @returns {Promise<Socket>} Resolves a TCP Socket
    */
   _connect (ma, options = {}) {

--- a/src/listener.js
+++ b/src/listener.js
@@ -115,7 +115,7 @@ module.exports = ({ handler, upgrader }, options) => {
     try {
       maConn = toConnection(socket, { listeningAddr })
       log('new inbound connection %s', maConn.remoteAddr)
-      conn = await upgrader.upgradeInbound(maConn)
+      conn = await upgrader.upgradeInbound(maConn, options)
     } catch (err) {
       log.error('inbound connection failed', err)
       // @ts-ignore

--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -59,7 +59,7 @@ const toConnection = (socket, options) => {
             yield Buffer.isBuffer(chunk) ? chunk : chunk.slice()
           }
         })())
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         // If aborted we can safely ignore
         if (err.type !== 'aborted') {
           // If the source errored the socket will already have been destroyed by
@@ -76,6 +76,7 @@ const toConnection = (socket, options) => {
 
     conn: socket,
 
+    // @ts-expect-error toMultiaddr guards the address and port args
     localAddr: options.localAddr || toMultiaddr(socket.localAddress, socket.localPort),
 
     // If the remote address was passed, use it - it may have the peer ID encapsulated


### PR DESCRIPTION
In order to abort in-progress dials and not leak memory, the abort signal must be passed to the upgrader in order for it to be passed on to mss and noise.

Refs: https://github.com/libp2p/js-libp2p/pull/1072