### PR TITLE
fix: if ending socket with error, destroy it in the end

### DIFF
--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -99,13 +99,14 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
           resolve()
         })
         socket.end((err?: Error & { code?: string }) => {
+          maConn.timeline.close = Date.now()
+
           if (err != null) {
             // the timer will destroy the socket in the end
             return reject(err)
           }
 
           clearTimeout(timeout)
-          maConn.timeline.close = Date.now()
           resolve()
         })
       })

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -99,11 +99,13 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
           resolve()
         })
         socket.end((err?: Error & { code?: string }) => {
-          clearTimeout(timeout)
-          maConn.timeline.close = Date.now()
           if (err != null) {
+            // the timer will destroy the socket in the end
             return reject(err)
           }
+
+          clearTimeout(timeout)
+          maConn.timeline.close = Date.now()
           resolve()
         })
       })


### PR DESCRIPTION
**Motivation**
- There are a lot of sockets retained, see #201
- When ending a socket with error, we clear the timer which make it unable to destroy the socket in the end

<img width="662" alt="Screen Shot 2022-08-30 at 13 47 45" src="https://user-images.githubusercontent.com/10568965/187368830-b0cc6bcc-aa20-438f-9c85-b6bf9427cb82.png">

**Description
- When ending socket and error happen, keep the timer so that socket is destroyed in the end