### PR TITLE
fix: add socket keepalive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export class TCP implements Transport {
 
   async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
     const socket = await this._connect(ma, options)
+    socket.setKeepAlive(true)
 
     // Avoid uncaught errors caused by unstable connections
     socket.on('error', err => {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -48,6 +48,8 @@ export function createListener (context: Context) {
   let listeningAddr: Multiaddr
 
   const server: ServerWithMultiaddrConnections = Object.assign(net.createServer(socket => {
+    socket.setKeepAlive(true)
+
     // Avoid uncaught errors caused by unstable connections
     socket.on('error', err => {
       log('socket error', err)

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -38,7 +38,17 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
     options.localAddr = options.remoteAddr
   }
 
-  const remoteAddr = options.remoteAddr ?? toMultiaddr(socket.remoteAddress ?? '', socket.remotePort ?? '')
+  let remoteAddr: Multiaddr
+
+  if (options.remoteAddr != null) {
+    remoteAddr = options.remoteAddr
+  } else {
+    const address = socket.address()
+
+    // @ts-expect-error type of address is `{} | AdressInfo` - how to exclude {}?
+    remoteAddr = toMultiaddr(address.address ?? '0.0.0.0', address.port ?? 0)
+  }
+
   const { host, port } = remoteAddr.toOptions()
   const { sink, source } = toIterable.duplex(socket)
 


### PR DESCRIPTION
This is consistent with go-libp2p for [incoming](https://github.com/libp2p/go-libp2p/blob/master/p2p/transport/tcp/tcp.go#L85)
and [outgoing](https://github.com/libp2p/go-libp2p/blob/master/p2p/transport/tcp/tcp.go#L191) connections