### PR TITLE
feat: Unix domain sockets

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 // p2p multi-address code
 export const CODE_P2P = 421
 export const CODE_CIRCUIT = 290
+export const CODE_UNIX = 400
 
 // Time to wait for a connection to close gracefully before destroying it manually
 export const CLOSE_TIMEOUT = 2000

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { toMultiaddrConnection } from './socket-to-conn.js'
 import { createListener } from './listener.js'
 import { multiaddrToNetConfig } from './utils.js'
 import { AbortError } from '@libp2p/interfaces/errors'
-import { CODE_CIRCUIT, CODE_P2P } from './constants.js'
+import { CODE_CIRCUIT, CODE_P2P, CODE_UNIX } from './constants.js'
 import { CreateListenerOptions, DialOptions, symbol, Transport } from '@libp2p/interface-transport'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Socket } from 'net'
@@ -153,6 +153,10 @@ export class TCP implements Transport {
     return multiaddrs.filter(ma => {
       if (ma.protoCodes().includes(CODE_CIRCUIT)) {
         return false
+      }
+
+      if (ma.protoCodes().includes(CODE_UNIX)) {
+        return true;
       }
 
       return mafmt.TCP.matches(ma.decapsulateCode(CODE_P2P))

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ export class TCP implements Transport {
     return await new Promise<Socket>((resolve, reject) => {
       const start = Date.now()
       const cOpts = multiaddrToNetConfig(ma) as (IpcSocketConnectOpts & TcpSocketConnectOpts)
-      const cOptsStr = cOpts.path ?? `${cOpts.host}:${cOpts.port}`
+      const cOptsStr = cOpts.path ?? `${cOpts.host ?? ''}:${cOpts.port}`
 
       log('dialing %j', cOpts)
       const rawSocket = net.connect(cOpts)
@@ -157,7 +157,7 @@ export class TCP implements Transport {
       }
 
       if (ma.protoCodes().includes(CODE_UNIX)) {
-        return true;
+        return true
       }
 
       return mafmt.TCP.matches(ma.decapsulateCode(CODE_P2P))

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -110,7 +110,7 @@ export function createListener (context: Context) {
       }
 
       if (typeof address === 'string') {
-        addrs = [ listeningAddr ]
+        addrs = [listeningAddr]
       } else if (listeningAddr.toString().startsWith('/ip4')) {
         // Because TCP will only return the IPv6 version
         // we need to capture from the passed multiaddr

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -110,12 +110,10 @@ export function createListener (context: Context) {
       }
 
       if (typeof address === 'string') {
-        throw new Error('Incorrect server address type')
-      }
-
-      // Because TCP will only return the IPv6 version
-      // we need to capture from the passed multiaddr
-      if (listeningAddr.toString().startsWith('/ip4')) {
+        addrs = [ listeningAddr ]
+      } else if (listeningAddr.toString().startsWith('/ip4')) {
+        // Because TCP will only return the IPv6 version
+        // we need to capture from the passed multiaddr
         addrs = addrs.concat(getMultiaddrs('ip4', address.address, address.port))
       } else if (address.family === 'IPv6') {
         addrs = addrs.concat(getMultiaddrs('ip6', address.address, address.port))

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -53,8 +53,8 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
     remoteAddr = toMultiaddr(socket.remoteAddress, socket.remotePort)
   }
 
-  const lOpts = multiaddrToNetConfig(remoteAddr);
-  const lOptsStr = lOpts.path ?? `${lOpts.host}:${lOpts.port}`
+  const lOpts = multiaddrToNetConfig(remoteAddr)
+  const lOptsStr = lOpts.path ?? `${lOpts.host ?? ''}:${lOpts.port ?? ''}`
   const { sink, source } = toIterable.duplex(socket)
 
   // by default there is no timeout

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -4,6 +4,7 @@ import { logger } from '@libp2p/logger'
 import toIterable from 'stream-to-it'
 import { ipPortToMultiaddr as toMultiaddr } from '@libp2p/utils/ip-port-to-multiaddr'
 import { CLOSE_TIMEOUT, SOCKET_TIMEOUT } from './constants.js'
+import { multiaddrToNetConfig } from './utils.js'
 import errCode from 'err-code'
 import type { Socket } from 'net'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -52,13 +53,14 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
     remoteAddr = toMultiaddr(socket.remoteAddress, socket.remotePort)
   }
 
-  const { host, port } = remoteAddr.toOptions()
+  const lOpts = multiaddrToNetConfig(remoteAddr);
+  const lOptsStr = lOpts.path ?? `${lOpts.host}:${lOpts.port}`
   const { sink, source } = toIterable.duplex(socket)
 
   // by default there is no timeout
   // https://nodejs.org/dist/latest-v16.x/docs/api/net.html#socketsettimeouttimeout-callback
   socket.setTimeout(inactivityTimeout, () => {
-    log('%s:%s socket read timeout', host, port)
+    log('%s socket read timeout', lOptsStr)
 
     // only destroy with an error if the remote has not sent the FIN message
     let err: Error | undefined
@@ -72,7 +74,7 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
   })
 
   socket.once('close', () => {
-    log('%s:%s socket closed', host, port)
+    log('%s socket read timeout', lOptsStr)
 
     // In instances where `close` was not explicitly called,
     // such as an iterable stream ending, ensure we have set the close
@@ -119,11 +121,11 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
 
     async close () {
       if (socket.destroyed) {
-        log('%s:%s socket was already destroyed when trying to close', host, port)
+        log('%s socket was already destroyed when trying to close', lOptsStr)
         return
       }
 
-      log('%s:%s closing socket', host, port)
+      log('%s closing socket', lOptsStr)
       await new Promise<void>((resolve, reject) => {
         const start = Date.now()
 
@@ -131,10 +133,10 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
         // timeout, destroy it manually.
         const timeout = setTimeout(() => {
           if (socket.destroyed) {
-            log('%s:%s is already destroyed', host, port)
+            log('%s is already destroyed', lOptsStr)
             resolve()
           } else {
-            log('%s:%s socket close timeout after %dms, destroying it manually', host, port, Date.now() - start)
+            log('%s socket close timeout after %dms, destroying it manually', lOptsStr, Date.now() - start)
 
             // will trigger 'error' and 'close' events that resolves promise
             socket.destroy(errCode(new Error('Socket close timeout'), 'ERR_SOCKET_CLOSE_TIMEOUT'))
@@ -142,13 +144,13 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
         }, closeTimeout).unref()
 
         socket.once('close', () => {
-          log('%s:%s socket closed', host, port)
+          log('%s socket closed', lOptsStr)
           // socket completely closed
           clearTimeout(timeout)
           resolve()
         })
         socket.once('error', (err: Error) => {
-          log('%s:%s socket error', host, port, err)
+          log('%s socket error', lOptsStr, err)
 
           // error closing socket
           if (maConn.timeline.close == null) {
@@ -171,7 +173,7 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
         if (socket.writableLength > 0) {
           // there are outgoing bytes waiting to be sent
           socket.once('drain', () => {
-            log('%s:%s socket drained', host, port)
+            log('%s socket drained', lOptsStr)
 
             // all bytes have been sent we can destroy the socket (maybe) before the timeout
             socket.destroy()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,15 @@
 import { Multiaddr } from '@multiformats/multiaddr'
+import type { ListenOptions, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
 import os from 'os'
 
 const ProtoFamily = { ip4: 'IPv4', ip6: 'IPv6' }
 
-export function multiaddrToNetConfig (addr: Multiaddr) {
+export function multiaddrToNetConfig (addr: Multiaddr): ListenOptions | (IpcSocketConnectOpts & TcpSocketConnectOpts) {
   const listenPath = addr.getPath()
 
   // unix socket listening
   if (listenPath != null) {
-    // TCP should not return unix socket else need to refactor listener which accepts connection options object
-    throw new Error('Unix Sockets are not supported by the TCP transport')
+    return { path: listenPath }
   }
 
   // tcp listening

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import { Multiaddr } from '@multiformats/multiaddr'
 import type { ListenOptions, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
 import os from 'os'
+import path from 'path'
 
 const ProtoFamily = { ip4: 'IPv4', ip6: 'IPv6' }
 
@@ -9,7 +10,12 @@ export function multiaddrToNetConfig (addr: Multiaddr): ListenOptions | (IpcSock
 
   // unix socket listening
   if (listenPath != null) {
-    return { path: listenPath }
+    if (os.platform() === 'win32') {
+      // Use named pipes on Windows systems.
+      return { path: path.join('\\\\.\\pipe\\', listenPath) }
+    } else {
+      return { path: listenPath }
+    }
   }
 
   // tcp listening

--- a/test/listen-dial.spec.ts
+++ b/test/listen-dial.spec.ts
@@ -224,7 +224,7 @@ describe('dial', () => {
       async (source) => await all(source)
     )
 
-		expect(values[0].subarray()).to.equalBytes(uint8ArrayFromString('hey'))
+    expect(values[0].subarray()).to.equalBytes(uint8ArrayFromString('hey'))
     await conn.close()
     await listener.close()
   })

--- a/test/listen-dial.spec.ts
+++ b/test/listen-dial.spec.ts
@@ -31,7 +31,7 @@ describe('listen', () => {
   })
 
   it('listen on path', async () => {
-    const mh = new Multiaddr(`/unix${path.resolve(os.tmpdir(), `/tmp/p2pd-${Date.now()}.sock`)}`)
+    const mh = new Multiaddr(`/unix/${path.resolve(os.tmpdir(), `/tmp/p2pd-${Date.now()}.sock`)}`)
 
     listener = tcp.createListener({
       upgrader
@@ -207,7 +207,7 @@ describe('dial', () => {
   })
 
   it('dial on path', async () => {
-    const ma = new Multiaddr(`/unix${path.resolve(os.tmpdir(), `/tmp/p2pd-${Date.now()}.sock`)}`)
+    const ma = new Multiaddr(`/unix/${path.resolve(os.tmpdir(), `/tmp/p2pd-${Date.now()}.sock`)}`)
 
     const listener = tcp.createListener({
       upgrader

--- a/test/listen-dial.spec.ts
+++ b/test/listen-dial.spec.ts
@@ -30,8 +30,7 @@ describe('listen', () => {
     }
   })
 
-  // TCP doesn't support unix paths
-  it.skip('listen on path', async () => {
+  it('listen on path', async () => {
     const mh = new Multiaddr(`/unix${path.resolve(os.tmpdir(), `/tmp/p2pd-${Date.now()}.sock`)}`)
 
     listener = tcp.createListener({
@@ -207,8 +206,7 @@ describe('dial', () => {
     await listener.close()
   })
 
-  // TCP doesn't support unix paths
-  it.skip('dial on path', async () => {
+  it('dial on path', async () => {
     const ma = new Multiaddr(`/unix${path.resolve(os.tmpdir(), `/tmp/p2pd-${Date.now()}.sock`)}`)
 
     const listener = tcp.createListener({
@@ -226,7 +224,7 @@ describe('dial', () => {
       async (source) => await all(source)
     )
 
-    expect(values).to.deep.equal(['hey'])
+		expect(values[0].subarray()).to.equalBytes(uint8ArrayFromString('hey'))
     await conn.close()
     await listener.close()
   })


### PR DESCRIPTION
This PR adds the functionality to handle UNIX domain sockets.

* This works with plain `/unix` multiaddresses but is unable to handle p2p encapsulated addresses (`/unix/.../p2p/...`) due to ambiguity. Because of this it causes errors when attempting to use `/unix` addresses in js-libp2p because it appends the `/p2p` address.
* On Windows this uses named pipes instead.

Despite the fact that it does not work with `/unix` addresses in js-libp2p directly, this still remains useful and is needed in other projects like [js-libp2p-daemon](https://github.com/libp2p/js-libp2p-daemon).

This PR relates to issue #132.