### PR TITLE
fix: expose extra options from net.connect for dial and listen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export interface TCPDialOptions extends DialOptions, TCPSocketOptions {
 
 }
 
-export interface TCPListenOptions extends CreateListenerOptions, TCPSocketOptions {
+export interface TCPCreateListenerOptions extends CreateListenerOptions, TCPSocketOptions {
 
 }
 
@@ -155,7 +155,7 @@ export class TCP implements Transport {
    * anytime a new incoming Connection has been successfully upgraded via
    * `upgrader.upgradeInbound`.
    */
-  createListener (options: TCPListenOptions) {
+  createListener (options: TCPCreateListenerOptions) {
     return createListener({
       ...options,
       socketInactivityTimeout: this.opts.inboundSocketInactivityTimeout,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,8 @@ import { multiaddrToNetConfig } from './utils.js'
 import { AbortError } from '@libp2p/interfaces/errors'
 import { CODE_CIRCUIT, CODE_P2P, CODE_UNIX } from './constants.js'
 import { CreateListenerOptions, DialOptions, symbol, Transport } from '@libp2p/interface-transport'
-import type { Multiaddr } from '@multiformats/multiaddr'
+import type { AbortOptions, Multiaddr } from '@multiformats/multiaddr'
 import type { Socket, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
-import type { AbortOptions } from '@libp2p/interfaces'
 import type { Connection } from '@libp2p/interface-connection'
 
 const log = logger('libp2p:tcp')
@@ -32,6 +31,24 @@ export interface TCPOptions {
   socketCloseTimeout?: number
 }
 
+/**
+ * Expose a subset of net.connect options
+ */
+ export interface TCPSocketOptions extends AbortOptions {
+  noDelay?: boolean
+  keepAlive?: boolean
+  keepAliveInitialDelay?: number
+  allowHalfOpen?: boolean
+}
+
+export interface TCPDialOptions extends DialOptions, TCPSocketOptions {
+
+}
+
+export interface TCPListenOptions extends CreateListenerOptions, TCPSocketOptions {
+
+}
+
 export class TCP implements Transport {
   private readonly opts: TCPOptions
 
@@ -47,9 +64,10 @@ export class TCP implements Transport {
     return '@libp2p/tcp'
   }
 
-  async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
+  async dial (ma: Multiaddr, options: TCPDialOptions): Promise<Connection> {
+    options.keepAlive = options.keepAlive ?? true
+
     const socket = await this._connect(ma, options)
-    socket.setKeepAlive(true)
 
     // Avoid uncaught errors caused by unstable connections
     socket.on('error', err => {
@@ -68,7 +86,7 @@ export class TCP implements Transport {
     return conn
   }
 
-  async _connect (ma: Multiaddr, options: AbortOptions = {}) {
+  async _connect (ma: Multiaddr, options: TCPDialOptions) {
     if (options.signal?.aborted === true) {
       throw new AbortError()
     }
@@ -137,7 +155,7 @@ export class TCP implements Transport {
    * anytime a new incoming Connection has been successfully upgraded via
    * `upgrader.upgradeInbound`.
    */
-  createListener (options: CreateListenerOptions) {
+  createListener (options: TCPListenOptions) {
     return createListener({
       ...options,
       socketInactivityTimeout: this.opts.inboundSocketInactivityTimeout,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export interface TCPOptions {
 /**
  * Expose a subset of net.connect options
  */
- export interface TCPSocketOptions extends AbortOptions {
+export interface TCPSocketOptions extends AbortOptions {
   noDelay?: boolean
   keepAlive?: boolean
   keepAliveInitialDelay?: number

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -11,6 +11,7 @@ import type { MultiaddrConnection, Connection } from '@libp2p/interface-connecti
 import type { Upgrader, Listener } from '@libp2p/interface-transport'
 import type { Server } from 'net'
 import type { Multiaddr } from '@multiformats/multiaddr'
+import type { TCPListenOptions } from './index.js'
 
 const log = logger('libp2p:tcp:listener')
 
@@ -29,7 +30,7 @@ async function attemptClose (maConn: MultiaddrConnection) {
   }
 }
 
-interface Context {
+interface Context extends TCPListenOptions {
   handler?: (conn: Connection) => void
   upgrader: Upgrader
   socketInactivityTimeout?: number
@@ -44,12 +45,12 @@ export function createListener (context: Context) {
     handler, upgrader, socketInactivityTimeout, socketCloseTimeout
   } = context
 
+  context.keepAlive = context.keepAlive ?? true
+
   let peerId: string | null
   let listeningAddr: Multiaddr
 
-  const server: ServerWithMultiaddrConnections = Object.assign(net.createServer(socket => {
-    socket.setKeepAlive(true)
-
+  const server: ServerWithMultiaddrConnections = Object.assign(net.createServer(context, socket => {
     // Avoid uncaught errors caused by unstable connections
     socket.on('error', err => {
       log('socket error', err)

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -11,7 +11,7 @@ import type { MultiaddrConnection, Connection } from '@libp2p/interface-connecti
 import type { Upgrader, Listener } from '@libp2p/interface-transport'
 import type { Server } from 'net'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { TCPListenOptions } from './index.js'
+import type { TCPCreateListenerOptions } from './index.js'
 
 const log = logger('libp2p:tcp:listener')
 
@@ -30,7 +30,7 @@ async function attemptClose (maConn: MultiaddrConnection) {
   }
 }
 
-interface Context extends TCPListenOptions {
+interface Context extends TCPCreateListenerOptions {
   handler?: (conn: Connection) => void
   upgrader: Upgrader
   socketInactivityTimeout?: number


### PR DESCRIPTION
To allow more flexibility in use of sockets, expose options from node's net.connect method.