### PR TITLE
feat: add metrics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,9 @@ import { CreateListenerOptions, DialOptions, Listener, symbol, Transport } from 
 import type { AbortOptions, Multiaddr } from '@multiformats/multiaddr'
 import type { Socket, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
 import type { Connection } from '@libp2p/interface-connection'
-import type { TcpMetrics } from './metrics.js'
+import { getMetrics, Metrics, MetricsRegister } from './metrics.js'
 
 const log = logger('libp2p:tcp')
-
-export { TcpMetrics }
 
 export interface TCPOptions {
   /**
@@ -60,11 +58,11 @@ export interface TCPCreateListenerOptions extends CreateListenerOptions, TCPSock
 
 class TCP implements Transport {
   private readonly opts: TCPOptions
-  private readonly metrics: TcpMetrics | null
+  private readonly metrics: Metrics | null
 
-  constructor (options: TCPOptions = {}, metrics?: TcpMetrics | null) {
+  constructor (options: TCPOptions = {}, metricsRegistry?: MetricsRegister | null) {
     this.opts = options
-    this.metrics = metrics ?? null
+    this.metrics = metricsRegistry != null ? getMetrics(metricsRegistry) : null
   }
 
   get [symbol] (): true {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -11,7 +11,7 @@ import type { MultiaddrConnection, Connection } from '@libp2p/interface-connecti
 import type { Upgrader, Listener, ListenerEvents } from '@libp2p/interface-transport'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { TCPCreateListenerOptions } from './index.js'
-import { ServerStatusMetric, TcpMetrics } from './metrics.js'
+import { ServerStatusMetric, Metrics } from './metrics.js'
 
 const log = logger('libp2p:tcp:listener')
 
@@ -32,7 +32,7 @@ interface Context extends TCPCreateListenerOptions {
   socketInactivityTimeout?: number
   socketCloseTimeout?: number
   maxConnections?: number
-  metrics: TcpMetrics | null
+  metrics: Metrics | null
 }
 
 type Status = {started: false} | {started: true, listeningAddr: Multiaddr, peerId: string | null }
@@ -41,7 +41,7 @@ export class TCPListener extends EventEmitter<ListenerEvents> implements Listene
   private readonly server: net.Server
   /** Keep track of open connections to destroy in case of timeout */
   private readonly connections = new Set<MultiaddrConnection>()
-  private readonly metrics: TcpMetrics | null
+  private readonly metrics: Metrics | null
 
   private status: Status = { started: false }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,11 +1,53 @@
+export enum ServerStatusMetric {
+  stopped = 0,
+  started = 1
+}
+
+export function getMetrics (register: MetricsRegister) {
+  return {
+    serverStatus: register.gauge({
+      name: 'libp2p_tcp_server_status',
+      help: 'Current status of the TCP server'
+    }),
+
+    connections: register.gauge({
+      name: 'libp2p_tcp_connections_count',
+      help: 'Current active connections in TCP listener'
+    }),
+
+    listenerErrors: register.gauge<{ error: string }>({
+      name: 'libp2p_tcp_listener_errors_total',
+      help: 'Total count of TCP listener errors by error type',
+      labelNames: ['error']
+    }),
+
+    socketEvents: register.gauge<{ event: string }>({
+      name: 'libp2p_tcp_socket_events',
+      help: 'Total count of TCP socket events by event',
+      labelNames: ['event']
+    })
+  }
+}
+
+export type Metrics = ReturnType<typeof getMetrics>
+
 /* eslint-disable etc/prefer-interface, @typescript-eslint/method-signature-style */
+
+export interface MetricsRegister {
+  gauge<T extends LabelsGeneric>(config: GaugeConfig<T>): Gauge<T>
+}
+
+interface GaugeConfig<Labels extends LabelsGeneric> {
+  name: string
+  help: string
+  labelNames?: keyof Labels extends string ? Array<keyof Labels> : undefined
+}
 
 type LabelsGeneric = Record<string, string | undefined>
 type CollectFn<Labels extends LabelsGeneric> = (metric: Gauge<Labels>) => void
 
 interface Gauge<Labels extends LabelsGeneric = never> {
-  // Sorry for this mess, `prom-client` API choices are not great
-  // If the function signature was `inc(value: number, labels?: Labels)`, this would be simpler
+  // Follows `prom-client` API choices, to require less middleware on consumer
   inc(value?: number): void
   inc(labels: Labels, value?: number): void
   inc(arg1?: Labels | number, arg2?: number): void
@@ -19,16 +61,4 @@ interface Gauge<Labels extends LabelsGeneric = never> {
   set(arg1?: Labels | number, arg2?: number): void
 
   addCollect(collectFn: CollectFn<Labels>): void
-}
-
-export enum ServerStatusMetric {
-  stopped = 0,
-  started = 1
-}
-
-export interface TcpMetrics {
-  serverStatus: Gauge
-  connections: Gauge
-  listenerErrors: Gauge<{error: string}>
-  socketEvents: Gauge<{event: string}>
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,34 @@
+/* eslint-disable etc/prefer-interface, @typescript-eslint/method-signature-style */
+
+type LabelsGeneric = Record<string, string | undefined>
+type CollectFn<Labels extends LabelsGeneric> = (metric: Gauge<Labels>) => void
+
+interface Gauge<Labels extends LabelsGeneric = never> {
+  // Sorry for this mess, `prom-client` API choices are not great
+  // If the function signature was `inc(value: number, labels?: Labels)`, this would be simpler
+  inc(value?: number): void
+  inc(labels: Labels, value?: number): void
+  inc(arg1?: Labels | number, arg2?: number): void
+
+  dec(value?: number): void
+  dec(labels: Labels, value?: number): void
+  dec(arg1?: Labels | number, arg2?: number): void
+
+  set(value: number): void
+  set(labels: Labels, value: number): void
+  set(arg1?: Labels | number, arg2?: number): void
+
+  addCollect(collectFn: CollectFn<Labels>): void
+}
+
+export enum ServerStatusMetric {
+  stopped = 0,
+  started = 1
+}
+
+export interface TcpMetrics {
+  serverStatus: Gauge
+  connections: Gauge
+  listenerErrors: Gauge<{error: string}>
+  socketEvents: Gauge<{event: string}>
+}

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -9,6 +9,7 @@ import errCode from 'err-code'
 import type { Socket } from 'net'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { MultiaddrConnection } from '@libp2p/interface-connection'
+import type { TcpMetrics } from './metrics.js'
 
 const log = logger('libp2p:tcp:socket')
 
@@ -19,14 +20,15 @@ interface ToConnectionOptions {
   signal?: AbortSignal
   socketInactivityTimeout?: number
   socketCloseTimeout?: number
+  metrics?: TcpMetrics | null
 }
 
 /**
  * Convert a socket into a MultiaddrConnection
  * https://github.com/libp2p/interface-transport#multiaddrconnection
  */
-export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOptions) => {
-  options = options ?? {}
+export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptions) => {
+  const metrics = options.metrics
   const inactivityTimeout = options.socketInactivityTimeout ?? SOCKET_TIMEOUT
   const closeTimeout = options.socketCloseTimeout ?? CLOSE_TIMEOUT
 
@@ -61,6 +63,7 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
   // https://nodejs.org/dist/latest-v16.x/docs/api/net.html#socketsettimeouttimeout-callback
   socket.setTimeout(inactivityTimeout, () => {
     log('%s socket read timeout', lOptsStr)
+    metrics?.socketEvents.inc({ event: 'timeout' })
 
     // only destroy with an error if the remote has not sent the FIN message
     let err: Error | undefined
@@ -75,6 +78,7 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
 
   socket.once('close', () => {
     log('%s socket read timeout', lOptsStr)
+    metrics?.socketEvents.inc({ event: 'close' })
 
     // In instances where `close` was not explicitly called,
     // such as an iterable stream ending, ensure we have set the close
@@ -88,6 +92,7 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
     // the remote sent a FIN packet which means no more data will be sent
     // https://nodejs.org/dist/latest-v16.x/docs/api/net.html#event-end
     log('socket ended', maConn.remoteAddr.toString())
+    metrics?.socketEvents.inc({ event: 'end' })
   })
 
   const maConn: MultiaddrConnection = {

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -9,7 +9,7 @@ import errCode from 'err-code'
 import type { Socket } from 'net'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { MultiaddrConnection } from '@libp2p/interface-connection'
-import type { TcpMetrics } from './metrics.js'
+import type { Metrics } from './metrics.js'
 
 const log = logger('libp2p:tcp:socket')
 
@@ -20,7 +20,7 @@ interface ToConnectionOptions {
   signal?: AbortSignal
   socketInactivityTimeout?: number
   socketCloseTimeout?: number
-  metrics?: TcpMetrics | null
+  metrics?: Metrics | null
 }
 
 /**


### PR DESCRIPTION
- Extends https://github.com/libp2p/js-libp2p-tcp/pull/214

Adds metrics for Prometheus-like collecting engine:
- serverStatus: If server is listening or not
- connections: Current count of active connections from internal net server data structures
- listenerErrors: Total count of relevant errors by error type
- socketEvents: Total count of socket events by type