### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ $ npm i @libp2p/tcp
 ## Usage
 
 ```js
-import { TCP } from '@libp2p/tcp'
+import { tcp } from '@libp2p/tcp'
 import { multiaddr } from '@multiformats/multiaddr'
-import {pipe} from 'it-pipe'
+import { pipe } from 'it-pipe'
 import all from 'it-all'
 
 // A simple upgrader that just returns the MultiaddrConnection
@@ -47,9 +47,9 @@ const upgrader = {
   upgradeOutbound: async maConn => maConn
 }
 
-const tcp = new TCP()
+const transport = tcp()()
 
-const listener = tcp.createListener({
+const listener = transport.createListener({
   upgrader,
   handler: (socket) => {
     console.log('new connection opened')
@@ -64,7 +64,7 @@ const addr = multiaddr('/ip4/127.0.0.1/tcp/9090')
 await listener.listen(addr)
 console.log('listening')
 
-const socket = await tcp.dial(addr, { upgrader })
+const socket = await transport.dial(addr, { upgrader })
 const values = await pipe(
   socket,
   all
@@ -89,7 +89,7 @@ Value: hello World!
 
 [![](https://raw.githubusercontent.com/libp2p/js-libp2p-interfaces/master/packages/libp2p-interfaces/src/transport/img/badge.png)](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-interfaces/src/transport)
 
-`libp2p-tcp` accepts TCP addresses as both IPFS and non IPFS encapsulated addresses, i.e:
+`@libp2p/tcp` accepts TCP addresses as both IPFS and non IPFS encapsulated addresses, i.e:
 
 `/ip4/127.0.0.1/tcp/4001`
 `/ip4/127.0.0.1/tcp/4001/ipfs/QmHash`

--- a/package.json
+++ b/package.json
@@ -148,13 +148,13 @@
     "stream-to-it": "^0.2.2"
   },
   "devDependencies": {
-    "@libp2p/interface-mocks": "^6.0.0",
-    "@libp2p/interface-transport-compliance-tests": "^2.0.6",
+    "@libp2p/interface-mocks": "^7.0.1",
+    "@libp2p/interface-transport-compliance-tests": "^3.0.0",
     "aegir": "^37.5.3",
     "it-all": "^1.0.6",
     "it-pipe": "^2.0.3",
     "p-defer": "^4.0.0",
     "sinon": "^14.0.0",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^4.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export interface TCPCreateListenerOptions extends CreateListenerOptions, TCPSock
 
 }
 
-export class TCP implements Transport {
+class TCP implements Transport {
   private readonly opts: TCPOptions
 
   constructor (options: TCPOptions = {}) {
@@ -187,5 +187,11 @@ export class TCP implements Transport {
 
       return mafmt.TCP.matches(ma.decapsulateCode(CODE_P2P))
     })
+  }
+}
+
+export function tcp (init: TCPOptions = {}): (components?: any) => Transport {
+  return () => {
+    return new TCP(init)
   }
 }

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -2,12 +2,12 @@ import sinon from 'sinon'
 import tests from '@libp2p/interface-transport-compliance-tests'
 import { multiaddr } from '@multiformats/multiaddr'
 import net from 'net'
-import { TCP } from '../src/index.js'
+import { tcp } from '../src/index.js'
 
 describe('interface-transport compliance', () => {
   tests({
     async setup () {
-      const tcp = new TCP()
+      const transport = tcp()()
       const addrs = [
         multiaddr('/ip4/127.0.0.1/tcp/9091'),
         multiaddr('/ip4/127.0.0.1/tcp/9092'),
@@ -35,7 +35,7 @@ describe('interface-transport compliance', () => {
         }
       }
 
-      return { transport: tcp, addrs, connector }
+      return { transport, addrs, connector }
     },
     async teardown () {}
   })

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -1,16 +1,16 @@
 import { expect } from 'aegir/chai'
-import { TCP } from '../src/index.js'
+import { tcp } from '../src/index.js'
 import { multiaddr } from '@multiformats/multiaddr'
 import { mockUpgrader } from '@libp2p/interface-mocks'
 import type { Connection } from '@libp2p/interface-connection'
-import type { Upgrader } from '@libp2p/interface-transport'
+import type { Transport, Upgrader } from '@libp2p/interface-transport'
 
 describe('valid localAddr and remoteAddr', () => {
-  let tcp: TCP
+  let transport: Transport
   let upgrader: Upgrader
 
   beforeEach(() => {
-    tcp = new TCP()
+    transport = tcp()()
     upgrader = mockUpgrader()
   })
 
@@ -24,7 +24,7 @@ describe('valid localAddr and remoteAddr', () => {
     const handler = (conn: Connection) => handled(conn)
 
     // Create a listener with the handler
-    const listener = tcp.createListener({
+    const listener = transport.createListener({
       handler,
       upgrader
     })
@@ -36,7 +36,7 @@ describe('valid localAddr and remoteAddr', () => {
     expect(localAddrs.length).to.equal(1)
 
     // Dial to that address
-    await tcp.dial(localAddrs[0], {
+    await transport.dial(localAddrs[0], {
       upgrader
     })
 
@@ -55,7 +55,7 @@ describe('valid localAddr and remoteAddr', () => {
     const handler = (conn: Connection) => handled(conn)
 
     // Create a listener with the handler
-    const listener = tcp.createListener({
+    const listener = transport.createListener({
       handler,
       upgrader
     })
@@ -67,7 +67,7 @@ describe('valid localAddr and remoteAddr', () => {
     expect(localAddrs.length).to.equal(1)
 
     // Dial to that address
-    const dialerConn = await tcp.dial(localAddrs[0], {
+    const dialerConn = await transport.dial(localAddrs[0], {
       upgrader
     })
 

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -1,15 +1,16 @@
 import { expect } from 'aegir/chai'
-import { TCP } from '../src/index.js'
+import { tcp } from '../src/index.js'
 import { multiaddr } from '@multiformats/multiaddr'
+import type { Transport } from '@libp2p/interface-transport'
 
 describe('filter addrs', () => {
   const base = '/ip4/127.0.0.1'
   const ipfs = '/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw'
 
-  let tcp: TCP
+  let transport: Transport
 
   before(() => {
-    tcp = new TCP()
+    transport = tcp()()
   })
 
   it('filter valid addrs for this transport', () => {
@@ -22,7 +23,7 @@ describe('filter addrs', () => {
     const ma7 = multiaddr('/dns4/libp2p.io/tcp/9090')
     const ma8 = multiaddr('/dnsaddr/libp2p.io/tcp/9090')
 
-    const valid = tcp.filter([ma1, ma2, ma3, ma4, ma5, ma6, ma7, ma8])
+    const valid = transport.filter([ma1, ma2, ma3, ma4, ma5, ma6, ma7, ma8])
     expect(valid.length).to.equal(4)
     expect(valid[0]).to.deep.equal(ma1)
     expect(valid[1]).to.deep.equal(ma4)
@@ -31,7 +32,7 @@ describe('filter addrs', () => {
   it('filter a single addr for this transport', () => {
     const ma1 = multiaddr(base + '/tcp/9090')
 
-    const valid = tcp.filter([ma1])
+    const valid = transport.filter([ma1])
     expect(valid.length).to.equal(1)
     expect(valid[0]).to.eql(ma1)
   })

--- a/test/max-connections.spec.ts
+++ b/test/max-connections.spec.ts
@@ -3,7 +3,7 @@ import net from 'node:net'
 import { promisify } from 'node:util'
 import { mockUpgrader } from '@libp2p/interface-mocks'
 import { multiaddr } from '@multiformats/multiaddr'
-import { TCP } from '../src/index.js'
+import { tcp } from '../src/index.js'
 
 describe('maxConnections', () => {
   const afterEachCallbacks: Array<() => Promise<any> | any> = []
@@ -18,10 +18,10 @@ describe('maxConnections', () => {
     const port = 9900
 
     const seenRemoteConnections = new Set<string>()
-    const tcp = new TCP({ maxConnections })
+    const trasnport = tcp({ maxConnections })()
 
     const upgrader = mockUpgrader()
-    const listener = tcp.createListener({ upgrader })
+    const listener = trasnport.createListener({ upgrader })
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     afterEachCallbacks.push(() => listener.close())
     await listener.listen(multiaddr(`/ip4/127.0.0.1/tcp/${port}`))


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection