### PR TITLE
fix: remove abortable-iterator and close socket directly on abort

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "@libp2p/utils": "^3.0.2",
     "@multiformats/mafmt": "^11.0.3",
     "@multiformats/multiaddr": "^11.0.0",
-    "abortable-iterator": "^4.0.2",
     "err-code": "^3.0.1",
     "stream-to-it": "^0.2.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ class TCP implements Transport {
 
     options.signal?.removeEventListener('abort', onAbort)
 
-    if (options.signal?.aborted) {
+    if (options.signal?.aborted === true) {
       conn.close().catch(err => {
         log.error('Error closing conn after abort', err)
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ class TCP implements Transport {
   async dial (ma: Multiaddr, options: TCPDialOptions): Promise<Connection> {
     options.keepAlive = options.keepAlive ?? true
 
+    // options.signal destroys the socket before 'connect' event
     const socket = await this._connect(ma, options)
 
     // Avoid uncaught errors caused by unstable connections
@@ -82,13 +83,19 @@ class TCP implements Transport {
 
     const maConn = toMultiaddrConnection(socket, {
       remoteAddr: ma,
-      signal: options.signal,
       socketInactivityTimeout: this.opts.outboundSocketInactivityTimeout,
       socketCloseTimeout: this.opts.socketCloseTimeout
     })
+
+    const onAbort = () => socket.end()
+    options.signal?.addEventListener('abort', onAbort, { once: true })
+
     log('new outbound connection %s', maConn.remoteAddr)
     const conn = await options.upgrader.upgradeOutbound(maConn)
     log('outbound connection %s upgraded', maConn.remoteAddr)
+
+    options.signal?.removeEventListener('abort', onAbort)
+
     return conn
   }
 

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -1,4 +1,3 @@
-import { abortableSource } from 'abortable-iterator'
 import { logger } from '@libp2p/logger'
 // @ts-expect-error no types
 import toIterable from 'stream-to-it'
@@ -16,7 +15,6 @@ interface ToConnectionOptions {
   listeningAddr?: Multiaddr
   remoteAddr?: Multiaddr
   localAddr?: Multiaddr
-  signal?: AbortSignal
   socketInactivityTimeout?: number
   socketCloseTimeout?: number
 }
@@ -92,10 +90,6 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
 
   const maConn: MultiaddrConnection = {
     async sink (source) {
-      if ((options?.signal) != null) {
-        source = abortableSource(source, options.signal)
-      }
-
       try {
         await sink(source)
       } catch (err: any) {
@@ -112,7 +106,7 @@ export const toMultiaddrConnection = (socket: Socket, options?: ToConnectionOpti
       socket.end()
     },
 
-    source: (options.signal != null) ? abortableSource(source, options.signal) : source,
+    source,
 
     // If the remote address was passed, use it - it may have the peer ID encapsulated
     remoteAddr,

--- a/test/listen-dial.spec.ts
+++ b/test/listen-dial.spec.ts
@@ -352,7 +352,7 @@ describe('dial', () => {
     const abortController = new AbortController()
 
     // abort once the upgrade process has started
-    maConnPromise.promise.then(() => abortController.abort())
+    void maConnPromise.promise.then(() => abortController.abort())
 
     await expect(transport.dial(ma, {
       upgrader,

--- a/test/listen-dial.spec.ts
+++ b/test/listen-dial.spec.ts
@@ -356,7 +356,7 @@ describe('dial', () => {
     const abortController = new AbortController()
 
     // abort once the upgrade process has started
-    upgradeProcessStarted.promise.then(() => abortController.abort())
+    void upgradeProcessStarted.promise.then(() => abortController.abort())
 
     await expect(transport.dial(ma, {
       upgrader,


### PR DESCRIPTION
- Usage of abortable has a non-negligible cost, see https://github.com/libp2p/js-libp2p/issues/1420

I believe abortable is not necessary in this package, since we can kill the socket directly.