### PR TITLE
fix: handle listen error

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -155,10 +155,10 @@ export class TCPListener extends EventEmitter<ListenerEvents> implements Listene
 
     return await new Promise<void>((resolve, reject) => {
       const options = multiaddrToNetConfig(listeningAddr)
-      this.server.listen(options, (err?: any) => {
-        if (err != null) {
-          return reject(err)
-        }
+      this.server.on('error', (err) => {
+        reject(err)
+      })
+      this.server.listen(options, () => {
         log('Listening on %s', this.server.address())
         resolve()
       })

--- a/test/listen-dial.spec.ts
+++ b/test/listen-dial.spec.ts
@@ -47,6 +47,22 @@ describe('listen', () => {
     await listener.listen(mh)
   })
 
+  it('errors when listening on busy port', async () => {
+    const mh = multiaddr('/ip4/127.0.0.1/tcp/0')
+    listener = transport.createListener({
+      upgrader
+    })
+    await listener.listen(mh)
+
+    const listener2 = transport.createListener({
+      upgrader
+    })
+
+    const mh2 = listener.getAddrs()[0]
+    await expect(listener2.listen(mh2)).to.eventually.be.rejected()
+      .with.property('code', 'EADDRINUSE')
+  })
+
   it('listen on IPv6 addr', async () => {
     if (isCI != null) {
       return


### PR DESCRIPTION
The `net.Server` `.listen` callback is not a node-style callback that gets passed an error, it's a listener for the `listen` event.

To handle errors when `.listen`ing, one must listen for the `error` event, so update the code to do that and add a test to prevent regressions.