### PR TITLE
fix: use labels to differentiate interfaces for metrics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,6 @@ export interface TCPComponents {
 
 export interface TCPMetrics {
   dialerEvents: CounterGroup
-  listenerEvents: CounterGroup
 }
 
 class TCP implements Transport {
@@ -76,13 +75,9 @@ class TCP implements Transport {
 
     if (components.metrics != null) {
       this.metrics = {
-        dialerEvents: components.metrics.registerCounterGroup('libp2p_tcp_dialer_errors_total', {
+        dialerEvents: components.metrics.registerCounterGroup('libp2p_tcp_dialer_events_total', {
           label: 'event',
-          help: 'Total count of TCP dialer errors by error type'
-        }),
-        listenerEvents: components.metrics.registerCounterGroup('libp2p_tcp_listener_errors_total', {
-          label: 'event',
-          help: 'Total count of TCP listener errors by error type'
+          help: 'Total count of TCP dialer events by type'
         })
       }
     }
@@ -115,7 +110,7 @@ class TCP implements Transport {
     })
     log('new outbound connection %s', maConn.remoteAddr)
     const conn = await options.upgrader.upgradeOutbound(maConn)
-    log('outbound connection %s upgraded', maConn.remoteAddr)
+    log('outbound connection upgraded %s', maConn.remoteAddr)
     return conn
   }
 


### PR DESCRIPTION
Instead of inserting the interface address into the metric name, use the metric address as a label prefix for the value being reported.

This allows our metric names to be stable even if you don't know the ip/port combo that will be used ahead of time.

The tradeoff is the label names may change between restarts if the port number changes, but we have to apply a disambguator somewhere.

Depends on:

- [x] https://github.com/libp2p/js-libp2p-prometheus-metrics/pull/6