### PR TITLE
test: fix tests on node 18

### DIFF
--- a/test/max-connections.spec.ts
+++ b/test/max-connections.spec.ts
@@ -18,10 +18,10 @@ describe('maxConnections', () => {
     const port = 9900
 
     const seenRemoteConnections = new Set<string>()
-    const trasnport = tcp({ maxConnections })()
+    const transport = tcp({ maxConnections })()
 
     const upgrader = mockUpgrader()
-    const listener = trasnport.createListener({ upgrader })
+    const listener = transport.createListener({ upgrader })
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     afterEachCallbacks.push(() => listener.close())
     await listener.listen(multiaddr(`/ip4/127.0.0.1/tcp/${port}`))
@@ -33,7 +33,7 @@ describe('maxConnections', () => {
     const sockets: net.Socket[] = []
 
     for (let i = 0; i < socketCount; i++) {
-      const socket = net.connect({ port })
+      const socket = net.connect({ host: '127.0.0.1', port })
       sockets.push(socket)
 
       // eslint-disable-next-line @typescript-eslint/promise-function-async


### PR DESCRIPTION
We need to specify the host name to connect. If we don't it defaults to `localhost` - it seems in node 17+ DNS resolution has changed to return IPv6 addresses by default which causes the connection to fail because the listener has only bound to an IPv4 address.