### PR TITLE
chore: replace err-code with CodeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,12 +144,11 @@
     "@libp2p/interface-connection": "^3.0.2",
     "@libp2p/interface-metrics": "^4.0.0",
     "@libp2p/interface-transport": "^2.0.0",
-    "@libp2p/interfaces": "^3.0.3",
+    "@libp2p/interfaces": "^3.2.0",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/utils": "^3.0.2",
     "@multiformats/mafmt": "^11.0.3",
     "@multiformats/multiaddr": "^11.0.0",
-    "err-code": "^3.0.1",
     "stream-to-it": "^0.2.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import net from 'net'
 import * as mafmt from '@multiformats/mafmt'
-import errCode from 'err-code'
 import { logger } from '@libp2p/logger'
 import { toMultiaddrConnection } from './socket-to-conn.js'
 import { TCPListener } from './listener.js'
 import { multiaddrToNetConfig } from './utils.js'
-import { AbortError } from '@libp2p/interfaces/errors'
+import { AbortError, CodeError } from '@libp2p/interfaces/errors'
 import { CODE_CIRCUIT, CODE_P2P, CODE_UNIX } from './constants.js'
 import { CreateListenerOptions, DialOptions, Listener, symbol, Transport } from '@libp2p/interface-transport'
 import type { AbortOptions, Multiaddr } from '@multiformats/multiaddr'
@@ -157,7 +156,7 @@ class TCP implements Transport {
         log('connection timeout %s', cOptsStr)
         this.metrics?.dialerEvents.increment({ timeout: true })
 
-        const err = errCode(new Error(`connection timeout after ${Date.now() - start}ms`), 'ERR_CONNECT_TIMEOUT')
+        const err = new CodeError(`connection timeout after ${Date.now() - start}ms`, 'ERR_CONNECT_TIMEOUT')
         // Note: this will result in onError() being called
         rawSocket.emit('error', err)
       }

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -4,7 +4,7 @@ import toIterable from 'stream-to-it'
 import { ipPortToMultiaddr as toMultiaddr } from '@libp2p/utils/ip-port-to-multiaddr'
 import { CLOSE_TIMEOUT, SOCKET_TIMEOUT } from './constants.js'
 import { multiaddrToNetConfig } from './utils.js'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import type { Socket } from 'net'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { MultiaddrConnection } from '@libp2p/interface-connection'
@@ -49,7 +49,7 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
     if (socket.remoteAddress == null || socket.remotePort == null) {
       // this can be undefined if the socket is destroyed (for example, if the client disconnected)
       // https://nodejs.org/dist/latest-v16.x/docs/api/net.html#socketremoteaddress
-      throw errCode(new Error('Could not determine remote address or port'), 'ERR_NO_REMOTE_ADDRESS')
+      throw new CodeError('Could not determine remote address or port', 'ERR_NO_REMOTE_ADDRESS')
     }
 
     remoteAddr = toMultiaddr(socket.remoteAddress, socket.remotePort)
@@ -68,7 +68,7 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
     // only destroy with an error if the remote has not sent the FIN message
     let err: Error | undefined
     if (socket.readable) {
-      err = errCode(new Error('Socket read timeout'), 'ERR_SOCKET_READ_TIMEOUT')
+      err = new CodeError('Socket read timeout', 'ERR_SOCKET_READ_TIMEOUT')
     }
 
     // if the socket times out due to inactivity we must manually close the connection
@@ -140,7 +140,7 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
             log('%s socket close timeout after %dms, destroying it manually', lOptsStr, Date.now() - start)
 
             // will trigger 'error' and 'close' events that resolves promise
-            socket.destroy(errCode(new Error('Socket close timeout'), 'ERR_SOCKET_CLOSE_TIMEOUT'))
+            socket.destroy(new CodeError('Socket close timeout', 'ERR_SOCKET_CLOSE_TIMEOUT'))
           }
         }, closeTimeout).unref()
 


### PR DESCRIPTION
Replaces [err-code](https://github.com/IndigoUnited/js-err-code/blob/master/index.js) with [CodeError](https://github.com/libp2p/js-libp2p-interfaces/pull/314)

Related: [js-libp2p#1269](https://github.com/libp2p/js-libp2p/issues/1269)

Changes

- removes err-code from dependencies
- adds @libp2p/interfaces@3.2.0 to dependencies
- uses CodeError in place of err-code
