### PR TITLE
fix: specify host explicitly in node tests

### DIFF
--- a/test/max-connections-close.spec.ts
+++ b/test/max-connections-close.spec.ts
@@ -32,7 +32,7 @@ describe('close server on maxConnections', () => {
     })
 
     function createSocket (): net.Socket {
-      const socket = net.connect({ port })
+      const socket = net.connect({ host: '127.0.0.1', port })
 
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       afterEachCallbacks.unshift(async () => {


### PR DESCRIPTION
github runners use ipv6 by default so if the server is listening on 127.0.0.1, then 127.0.0.1 needs to be explicitly dialed.