### PR TITLE
Use different port in max-connections-close test

### DIFF
--- a/test/max-connections-close.spec.ts
+++ b/test/max-connections-close.spec.ts
@@ -16,7 +16,7 @@ describe('close server on maxConnections', () => {
   it('reject dial of connection above closeAbove', async () => {
     const listenBelow = 2
     const closeAbove = 3
-    const port = 9900
+    const port = 9901
 
     const seenRemoteConnections = new Set<string>()
     const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()


### PR DESCRIPTION
Release CI is broken on this test https://github.com/libp2p/js-libp2p-tcp/actions/runs/3971032097/jobs/6814690159

```
  1) close server on maxConnections
       reject dial of connection above closeAbove:
     Socket[1] connect ECONNREFUSED ::1:9900
  Error: connect ECONNREFUSED ::1:9900
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1487:16)
```

I am not able to reproduce the error locally. The test is supposed to allow the first 3 connections (socket[1], socket[2], socket[3]). However, the first attempted socket fails to connect as apparently the server is not listening. The server should listen here and this promise resolve only when sockets can connect.

https://github.com/libp2p/js-libp2p-tcp/blob/07a03ac4cdb645393b6d7a5ec88059da034a9b45/test/max-connections-close.spec.ts#L28

This PR does not provide any guaranteed solution but just changes the port to ensure test `max-connections.spec.ts` does not conflict with `max-connections-close.spec.ts`.

Why is test CI only failing on release?