### PR TITLE
feat: add socket backlog option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export interface TCPSocketOptions extends AbortOptions {
   keepAlive?: boolean
   keepAliveInitialDelay?: number
   allowHalfOpen?: boolean
+  backlog?: number
 }
 
 export interface TCPDialOptions extends DialOptions, TCPSocketOptions {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -269,12 +269,14 @@ export class TCPListener extends EventEmitter<ListenerEvents> implements Listene
 
     const peerId = ma.getPeerId()
     const listeningAddr = peerId == null ? ma.decapsulateCode(CODE_P2P) : ma
+    const netConfig = multiaddrToNetConfig(listeningAddr)
+    const { backlog } = this.context
 
     this.status = {
       started: true,
       listeningAddr,
       peerId,
-      netConfig: multiaddrToNetConfig(listeningAddr)
+      netConfig: backlog ? { ...netConfig, backlog } : netConfig
     }
 
     await this.netListen()


### PR DESCRIPTION
**Motivation**
- Application, like lodestar, wants to have its own customized backlog option which is the maximum length of the queue of pending connection. See https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten

**Description**
- Add `backlog` option to TCPSocketOptions and consume it in `listen` function