### PR TITLE
fix: avoid Multiaddr.getPath() performance issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@libp2p/logger": "^2.0.0",
     "@libp2p/utils": "^3.0.2",
     "@multiformats/mafmt": "^12.0.0",
-    "@multiformats/multiaddr": "^12.0.0",
+    "@multiformats/multiaddr": "^12.1.2",
     "stream-to-it": "^0.2.2"
   },
   "devDependencies": {

--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -41,22 +41,24 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
     options.localAddr = options.remoteAddr
   }
 
+  let lOptsStr: string
   let remoteAddr: Multiaddr
 
   if (options.remoteAddr != null) {
     remoteAddr = options.remoteAddr
+    const lOpts = multiaddrToNetConfig(remoteAddr)
+    lOptsStr = lOpts.path ?? `${lOpts.host ?? ''}:${lOpts.port ?? ''}`
   } else {
     if (socket.remoteAddress == null || socket.remotePort == null) {
       // this can be undefined if the socket is destroyed (for example, if the client disconnected)
       // https://nodejs.org/dist/latest-v16.x/docs/api/net.html#socketremoteaddress
       throw new CodeError('Could not determine remote address or port', 'ERR_NO_REMOTE_ADDRESS')
     }
-
-    remoteAddr = toMultiaddr(socket.remoteAddress, socket.remotePort)
+    const { remoteAddress, remotePort } = socket
+    remoteAddr = toMultiaddr(remoteAddress, remotePort)
+    lOptsStr = `${remoteAddress ?? ''}:${remotePort ?? ''}`
   }
 
-  const lOpts = multiaddrToNetConfig(remoteAddr)
-  const lOptsStr = lOpts.path ?? `${lOpts.host ?? ''}:${lOpts.port ?? ''}`
   const { sink, source } = toIterable.duplex(socket)
 
   // by default there is no timeout


### PR DESCRIPTION
**Motivation**
- `multiaddr.getPath()` is not cheap, when there are tons of sockets connecting to node at the same time, it shows `getPath()` takes more than 33% of cpu time

<img width="1297" alt="Screenshot 2023-04-10 at 09 34 42" src="https://user-images.githubusercontent.com/10568965/230814150-ffc26f68-91ef-4a40-8522-f01dc9f454ef.png">

**Description**
Avoid calling `getPath` by:
- In `toMultiaddrConnection()`, the `getPath` call is for the listening multi address which we can cache in listener's status
- The other time we call `multiaddrToNetConfig()` for a remote address with ip and port just to print out log message for it. In this case, we can use the given ip and port of the remote address without calling that function