### PR TITLE
deps!: update stream types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules
-package-lock.json
-.coverage
-.nyc_output
-.docs
+build
 dist
+.docs
+.coverage
+node_modules
+package-lock.json
+yarn.lock
+.vscode

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [Usage](#usage)
 - [API Docs](#api-docs)
 - [License](#license)
-- [Contribute](#contribute)
+- [Contribution](#contribution)
 
 ## Install
 
@@ -82,6 +82,6 @@ Licensed under either of
 - Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
 - MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
-## Contribute
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/package.json
+++ b/package.json
@@ -141,9 +141,9 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-connection": "^4.0.0",
+    "@libp2p/interface-connection": "^5.0.0",
     "@libp2p/interface-metrics": "^4.0.0",
-    "@libp2p/interface-transport": "^2.0.0",
+    "@libp2p/interface-transport": "^3.0.0",
     "@libp2p/interfaces": "^3.2.0",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/utils": "^3.0.2",
@@ -152,7 +152,7 @@
     "stream-to-it": "^0.2.2"
   },
   "devDependencies": {
-    "@libp2p/interface-mocks": "^9.1.1",
+    "@libp2p/interface-mocks": "^10.0.0",
     "@libp2p/interface-transport-compliance-tests": "^3.0.0",
     "aegir": "^38.1.0",
     "it-all": "^3.0.1",


### PR DESCRIPTION
libp2p streams are now explicit about the types of sync/sources they provide, showing that they are `AsyncGenerator`s and not just `AsyncIterable`s.

Refs: https://github.com/achingbrain/it-stream-types/pull/45

BREAKING CHANGE: the type of the source/sink properties have changed